### PR TITLE
ci: add GitHub Actions workflow for lint, tests and dbt validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install
+        # dev  -> pytest, responses, ruff
+        # ml   -> scikit-learn, needed by tests/test_ml_evaluate.py
+        # transform -> dbt, for the project validation step below
+        run: pip install -e ".[dev,ml,transform]"
+
+      - name: Lint
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Test
+        # The suite is fully offline -- every external response is a recorded
+        # fixture -- so CI never depends on the ArcGIS or ECCC services being up.
+        run: pytest -q
+
+      - name: Validate dbt project
+        working-directory: transform
+        # `dbt build` needs the raw parquet, which is not committed (it is
+        # reproducible via `make extract`). `compile` against the in-memory `ci`
+        # target still catches the failures worth catching in review: broken
+        # refs, bad Jinja, models pointing at columns or sources that no longer
+        # exist. The data tests themselves run locally through `make build`.
+        run: |
+          dbt deps --profiles-dir .
+          dbt compile --profiles-dir . --target ci


### PR DESCRIPTION
## What this is

The CI workflow for the pipeline built across phases 0–4. It was written during phase 0 but could not be pushed at the time — the OAuth token lacked the `workflow` scope, so the file sat uncommitted in the working tree while phases 1–4 were merged (#6, #7). The scope has since been granted.

## Why it isn't just the phase 0 file

Two things were wrong with the version written back then, both of which would have shown up on the first run:

**It would have failed immediately.** It installed only the `dev` extra, so scikit-learn was absent — and `tests/test_ml_evaluate.py`, added in phase 4, imports `ml.evaluate` which needs it. Now installs `.[dev,ml,transform]`.

**It never validated the dbt project.** By the time it could be pushed, the repo had 17 dbt models and 58 data tests that CI was ignoring entirely. It now runs `dbt deps` and `dbt compile`.

## What it does

| Step | Covers |
|---|---|
| Lint | `ruff check` + `ruff format --check` |
| Test | 27 pytest tests |
| Validate dbt project | `dbt deps` + `dbt compile` against the in-memory `ci` target |

## Notes for review

**`dbt build` deliberately does not run in CI.** It needs the raw parquet under `data/raw/`, which isn't committed because it's reproducible from the live ArcGIS and ECCC APIs via `make extract`. Running `compile` against the in-memory `ci` target still catches the failures worth catching in review — broken `ref`s, bad Jinja, models selecting columns or sources that no longer exist. The 58 data tests run locally through `make build`. Seeding a fixture warehouse so the data tests run in CI is the obvious follow-up, but it's a separate piece of work.

**The python suite is fully offline.** Every external response — the ArcGIS layer definition, a GeoJSON page, the ECCC station splice — is a recorded fixture, and `tests/test_analysis_queries.py` builds a synthetic in-memory warehouse rather than reading the real one. CI never depends on those services being reachable.

**Verified locally before pushing:** ruff clean, 27 tests pass, `dbt compile --target ci` exits 0 with no warehouse file present.

## Not included

`notebooks/01_initial_preprocessing.ipynb` and `notebooks/02_baseline_eda.ipynb` still carry uncommitted local changes unrelated to this work — the `02_baseline_eda` diff alone is ~658k lines of re-executed cell output. They've been excluded from every PR in this series and remain in the working tree. Note that once this workflow is active, `ruff` will not touch them: `notebooks/` is excluded in `pyproject.toml` until the phase that rewrites them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
