### PR TITLE
feat: phase 5 scoring pipeline — forecast-year inspection list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 PY := .venv/bin/python
 
 .PHONY: help setup extract extract-breaks extract-mains extract-weather \
-        deps transform transform-test docs build figures model test lint fmt clean
+        deps transform transform-test docs build figures model score test lint fmt clean
 
 help:
 	@grep -E "^[a-z-]+:.*?## .*$$" $(MAKEFILE_LIST) | sed "s/:.*## /\t/" | expand -t22
@@ -40,15 +40,19 @@ docs:  ## Generate and serve the dbt lineage docs
 	cd transform && ../$(PY) -m dbt.cli.main docs generate --profiles-dir . && \
 		../$(PY) -m dbt.cli.main docs serve --profiles-dir .
 
-build:  ## Full pipeline: extract -> snapshot -> models -> tests
+build:  ## Full pipeline: extract -> snapshot -> models -> tests -> score
 	$(MAKE) extract
 	cd transform && ../$(PY) -m dbt.cli.main build --profiles-dir .
+	$(MAKE) score
 
 figures:  ## Regenerate the analysis figures from the marts
 	$(PY) -m analysis.run
 
 model:  ## Run the walk-forward modelling evaluation
 	$(PY) -m ml.run
+
+score:  ## Score the forecast year and write the inspection list
+	$(PY) -m ml.score
 
 test:  ## Run the offline python test suite
 	$(PY) -m pytest

--- a/docs/model-card.md
+++ b/docs/model-card.md
@@ -103,6 +103,67 @@ Both fixed: early stopping now uses AUC on the last three *training* years, with
 4. **No soil, pressure-transient, traffic-loading or work-order cost data.** These are the obvious next features, and their absence is the most likely reason a flexible model cannot beat a three-column lookup.
 5. **Kitchener only.** Waterloo is a separate municipality with its own portal.
 
+## Scoring pipeline (phase 5)
+
+`python -m ml.score` fits the ranker on complete years and scores the **forecast
+year** — one year past the current one, added to the panel spine specifically so
+there are rows to score. An inspection list for a year that is already half over
+is half useless.
+
+Output goes to `main_scores.fct_pipe_risk_score`, written by `ml/score.py` rather
+than dbt and kept in its own schema to make that ownership boundary visible.
+Each run appends, stamped with `scored_at` and a `method_version` derived from a
+hash of the fitted table's own contents.
+
+For 2027, over 15,552 segments and 938 km:
+
+| Budget | Length | Segments | Expected breaks | Share of expected |
+|---|---|---|---|---|
+| 1% | 9.2 km | 62 | 5.2 | 7% |
+| 2% | 18.7 km | 97 | 10.4 | 14% |
+| **5%** | **46.9 km** | **257** | **22.7** | **30%** |
+| 10% | 93.7 km | 620 | 38.3 | 51% |
+
+The 5% row reading 30% is an independent check on the walk-forward `capture@5%`
+of 30.1% — the two are computed by different code paths.
+
+### Explanation, not attribution
+
+A lookup table needs no SHAP. Every score carries its cell, that cell's rate,
+and the evidence beneath it:
+
+| Cell | Segments | km | Rate /100km/yr | Evidence |
+|---|---|---|---|---|
+| 3 prior \| CI \| 1950s | 90 | 17.8 | 56.3 | 123 breaks |
+| 3 prior \| DI \| 1970s | 17 | 3.4 | 48.3 | 21 breaks |
+| 3 prior \| CI \| 1960s | 83 | 16.9 | 43.5 | 102 breaks |
+| 2 prior \| CI \| 1950s | 50 | 7.4 | 41.4 | 78 breaks |
+
+`cell_is_unseen` flags rows whose score is the smoothing prior rather than
+observed history.
+
+### Per-segment rank carries no information
+
+111 cells cover ~15,500 segments, so most of the list is ordered by the
+tiebreak, not the score. Reversing it (longest-first instead of shortest-first)
+moves `capture@5%` from 29.3% to 28.4% across eight years — inside the noise.
+The app must therefore surface the **cell**, never imply that segment #204 is
+riskier than #205.
+
+### Champion and challenger
+
+Both scores are written per pipe. `score_per_100km` is the ranker and is what to
+act on; `challenger_score` is the LightGBM model, kept so the comparison keeps
+running against new data instead of being settled once in this document.
+
+### Drift
+
+Each run compares its score distribution (p50/p90/p99) to the previous run and
+flags a move over 25%. A refit on one more year should barely move; a large jump
+means something upstream changed — a join fanned out, a material got recoded, an
+extract came back short — and the scores should not be acted on until someone
+has looked.
+
 ## Not yet done
 
 Poisson/negative-binomial rate model with a `log(length_km)` offset, and survival models (Weibull AFT, Andersen–Gill) for recurrent events. Both are in the plan; neither is required for the recommendation above, which is that the simple ranker ships.

--- a/ml/baselines.py
+++ b/ml/baselines.py
@@ -130,11 +130,14 @@ def stratified_rate_score(train: pd.DataFrame, test: pd.DataFrame) -> np.ndarray
     other 94%; keying on all three lets one lookup table serve both without a
     hand-written branch.
 
-    Still just a group-by fitted on training years. That is the point -- it is
-    auditable by the engineer who has to act on the list, and a colleague can
-    reproduce it in SQL.
+    Delegates to `StratifiedRateRanker`, the class the scoring pipeline ships,
+    so the thing measured here is literally the thing deployed. Wiring the
+    evaluation to a reimplementation is how a model comes to score well in a
+    notebook and differently in production.
     """
-    return _empirical_rate(train, test, ["prior_break_count_capped", "material", "install_decade"])
+    from ml.ranker import StratifiedRateRanker
+
+    return StratifiedRateRanker().fit(train).predict(test)
 
 
 HONEST_BASELINES["stratified_rate"] = stratified_rate_score

--- a/ml/ranker.py
+++ b/ml/ranker.py
@@ -1,0 +1,126 @@
+"""The shipped ranker: a fitted lookup table.
+
+Phase 4 evaluated a gradient-boosted classifier against a set of simple
+baselines over ten walk-forward years. The classifier lost. On the 90% of the
+network with no break history it captured 20.6% of next year's breaks in the
+top 5% of length against a lookup table's 27.7%, beating it in one year out of
+ten; on pipes with history it captured 6.4% against 10.5%. See
+docs/model-card.md.
+
+So this is what ships: the empirical breaks-per-km of each
+`(prior_break_count, material, install_decade)` cell, fitted on complete
+training years. It matches the best method in every stratum, it is a GROUP BY,
+and the engineer who has to act on the list can check it by hand.
+
+The class exists rather than a bare function for three reasons the production
+path needs and an evaluation function does not: it can be fitted once and
+applied to several frames, it reports the evidence behind every score, and it
+carries a version derived from its own contents.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+
+DEFAULT_KEYS = ("prior_break_count_capped", "material", "install_decade")
+
+# Cells are shrunk toward the global rate in proportion to how little exposure
+# they carry. 20 km is roughly 2% of the network -- enough that a cell needs
+# real evidence before it can rank far from the average.
+DEFAULT_SMOOTHING_KM = 20.0
+
+
+@dataclass
+class StratifiedRateRanker:
+    """Breaks per km by (prior breaks, material, install decade)."""
+
+    keys: tuple[str, ...] = DEFAULT_KEYS
+    smoothing_km: float = DEFAULT_SMOOTHING_KM
+    table_: pd.DataFrame = field(default=None, repr=False)
+    global_rate_: float = field(default=np.nan)
+    trained_years_: tuple[int, ...] = field(default=())
+
+    def fit(self, train: pd.DataFrame) -> StratifiedRateRanker:
+        """Fit on complete panel years only.
+
+        Fitting on anything else would put the outcome of the year being
+        scored into the score -- the same mistake as the leaky condition_score,
+        just self-inflicted.
+        """
+        if "is_complete_year" in train.columns and not train["is_complete_year"].all():
+            raise ValueError(
+                "StratifiedRateRanker must be fitted on complete years only; "
+                "incomplete years have partially observed outcomes."
+            )
+
+        self.global_rate_ = float(train["break_count"].sum() / max(train["length_km"].sum(), 1e-9))
+        grouped = train.groupby(list(self.keys), observed=True).agg(
+            cell_breaks=("break_count", "sum"),
+            cell_exposure_km=("length_km", "sum"),
+            cell_pipe_years=("break_count", "size"),
+        )
+        grouped["cell_rate"] = (grouped["cell_breaks"] + self.smoothing_km * self.global_rate_) / (
+            grouped["cell_exposure_km"] + self.smoothing_km
+        )
+
+        self.table_ = grouped
+        self.trained_years_ = tuple(sorted(train["panel_year"].unique().tolist()))
+        return self
+
+    def _lookup(self, frame: pd.DataFrame) -> pd.DataFrame:
+        if self.table_ is None:
+            raise RuntimeError("ranker is not fitted")
+        keyed = pd.MultiIndex.from_frame(frame[list(self.keys)])
+        return self.table_.reindex(keyed).reset_index(drop=True)
+
+    def predict(self, frame: pd.DataFrame) -> np.ndarray:
+        """Expected breaks per km.
+
+        Per km, not per segment: the inspection budget is measured in
+        kilometres, so ranking by total expected breaks would push long pipes up
+        the list purely for being long.
+        """
+        return self._lookup(frame)["cell_rate"].fillna(self.global_rate_).to_numpy(dtype=float)
+
+    def explain(self, frame: pd.DataFrame) -> pd.DataFrame:
+        """The evidence behind each score.
+
+        A lookup table needs no SHAP: the explanation is the computation. Each
+        row gets its cell, that cell's historical rate, and how much pipe and
+        how many breaks that rate rests on -- which also exposes the cells whose
+        score is mostly the smoothing prior.
+        """
+        found = self._lookup(frame)
+        out = pd.DataFrame(index=frame.index)
+        for key in self.keys:
+            out[key] = frame[key].to_numpy()
+        out["risk_cell"] = [
+            " | ".join(str(v) for v in row) for row in frame[list(self.keys)].to_numpy()
+        ]
+        out["cell_rate_per_100km"] = 100.0 * found["cell_rate"].fillna(self.global_rate_).to_numpy()
+        out["cell_breaks"] = found["cell_breaks"].fillna(0).to_numpy()
+        out["cell_exposure_km"] = found["cell_exposure_km"].fillna(0).to_numpy()
+        out["cell_pipe_years"] = found["cell_pipe_years"].fillna(0).to_numpy()
+        out["cell_is_unseen"] = found["cell_rate"].isna().to_numpy()
+        return out
+
+    @property
+    def version(self) -> str:
+        """Content hash of the fitted table.
+
+        Two runs over identical data produce the same version; a changed cell,
+        a changed key set or another training year produces a different one. It
+        is what a stored score is stamped with, so a row can always be traced to
+        the table that produced it.
+        """
+        if self.table_ is None:
+            raise RuntimeError("ranker is not fitted")
+        payload = (
+            f"{self.keys}|{self.smoothing_km}|{self.trained_years_}|"
+            + self.table_.round(8).to_csv()
+        )
+        return "rate-" + hashlib.sha256(payload.encode()).hexdigest()[:12]

--- a/ml/score.py
+++ b/ml/score.py
@@ -1,0 +1,291 @@
+"""Score the forecast year and write the inspection list back to the warehouse.
+
+    python -m ml.score
+
+Produces `main_scores.fct_pipe_risk_score`: one row per pipe for the year
+ahead, ranked, with the evidence behind each score and a running kilometre
+budget so the list can be cut at whatever length the city can actually inspect.
+
+Two scores are written per pipe. `score_per_100km` comes from the
+StratifiedRateRanker and is the one to act on. `challenger_score` comes from the
+LightGBM model, which phase 4 found does not beat the lookup table -- it is kept
+so the comparison keeps running on new data rather than being settled once in a
+document. If the challenger starts winning, that is worth knowing.
+
+The table is written by this module, not by dbt, and lives in its own schema to
+keep that ownership boundary visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+from pathlib import Path
+
+import duckdb
+import numpy as np
+import pandas as pd
+
+from ml import features, train
+from ml.ranker import StratifiedRateRanker
+
+logger = logging.getLogger("ml.score")
+
+SCORE_SCHEMA = "main_scores"
+SCORE_TABLE = "fct_pipe_risk_score"
+FQ_TABLE = f"{SCORE_SCHEMA}.{SCORE_TABLE}"
+
+# Budgets the app surfaces, as a share of total network length.
+BUDGET_GRID = (0.01, 0.02, 0.05, 0.10)
+
+
+def load_scoring_frames(warehouse: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Complete years for fitting, the forecast year for scoring."""
+    with duckdb.connect(str(warehouse), read_only=True) as con:
+        panel = con.sql("""
+            select * from main_marts.fct_pipe_year
+            where is_complete_year and panel_year >= 2005 and not is_negligible_length
+        """).df()
+        # Negligible-length segments are excluded from the list for the same
+        # reason they are excluded from fitting: they are sub-metre GIS
+        # connector artifacts, not pipe anyone can inspect. Leaving them in put
+        # 80 cm stubs at the top of the first list this produced, because they
+        # share a cell rate with real pipe and win the shortest-first tiebreak.
+        forecast = con.sql("""
+            select * from main_marts.fct_pipe_year
+            where is_forecast_year and not is_negligible_length
+        """).df()
+
+    for frame in (panel, forecast):
+        frame[features.TARGET] = frame[features.TARGET].astype(int)
+        for column in features.CATEGORICAL:
+            frame[column] = frame[column].astype("category")
+        for column in features.STATIC_BOOLEAN:
+            frame[column] = frame[column].fillna(False).astype(int)
+        frame["years_since_last_break"] = frame["years_since_last_break"].fillna(999)
+
+    # Categories must match between fit and predict or LightGBM silently
+    # reindexes them and the challenger scores garbage.
+    for column in features.CATEGORICAL:
+        union = panel[column].cat.categories.union(forecast[column].cat.categories)
+        panel[column] = panel[column].cat.set_categories(union)
+        forecast[column] = forecast[column].cat.set_categories(union)
+
+    return panel, forecast
+
+
+def build_inspection_list(
+    ranker: StratifiedRateRanker,
+    forecast: pd.DataFrame,
+    challenger_scores: np.ndarray | None,
+    challenger_version: str | None,
+) -> pd.DataFrame:
+    """Rank the forecast year and attach the running budget."""
+    scores = ranker.predict(forecast)
+    out = pd.DataFrame(
+        {
+            "watmainid": forecast["watmainid"].to_numpy(),
+            "target_year": forecast["panel_year"].to_numpy(),
+            "length_km": forecast["length_km"].to_numpy(),
+            "score_per_100km": 100.0 * scores,
+            # Rate x length. Not the ranking quantity -- ranking on it would
+            # favour long pipes under a length budget -- but it is what lets the
+            # app say "these 47 km are expected to produce N breaks".
+            "expected_breaks": scores * forecast["length_km"].to_numpy(),
+        }
+    )
+    out = pd.concat([out, ranker.explain(forecast).reset_index(drop=True)], axis=1)
+
+    if challenger_scores is not None:
+        out["challenger_score"] = challenger_scores
+        out["challenger_rank"] = (
+            pd.Series(challenger_scores).rank(ascending=False, method="first").astype(int)
+        )
+    else:
+        out["challenger_score"] = np.nan
+        out["challenger_rank"] = pd.NA
+
+    # Ties are pervasive by construction -- 111 cells across ~15,500 segments --
+    # so most of the list is ordered by the tiebreak, not the score. Shortest
+    # first matches how capture@k is measured in ml.evaluate, which keeps the
+    # published 30% figure true of the list this actually produces.
+    #
+    # It does mean a precise rank within a cell carries no information. The app
+    # should show the cell and its rate, not imply that #204 is riskier than
+    # #205.
+    out = out.sort_values(["score_per_100km", "length_km"], ascending=[False, True])
+    out["rank"] = np.arange(1, len(out) + 1)
+    out["cumulative_km"] = out["length_km"].cumsum()
+    out["cumulative_expected_breaks"] = out["expected_breaks"].cumsum()
+    out["pct_of_network_km"] = out["cumulative_km"] / out["length_km"].sum()
+
+    out["method_version"] = ranker.version
+    out["challenger_version"] = challenger_version
+    out["scored_at"] = pd.Timestamp.now(tz="UTC")
+    return out.reset_index(drop=True)
+
+
+def drift_report(con: duckdb.DuckDBPyConnection, new: pd.DataFrame) -> dict | None:
+    """Compare this run's score distribution to the previous one.
+
+    A ranker refitted on a year of new data should move a little. A large jump
+    means something upstream changed -- a join fanned out, a material got
+    recoded, an extract came back short -- and the scores should not be trusted
+    until someone has looked.
+    """
+    exists = con.sql(f"""
+        select count(*) as n from information_schema.tables
+        where table_schema = '{SCORE_SCHEMA}' and table_name = '{SCORE_TABLE}'
+    """).fetchone()[0]
+    if not exists:
+        return None
+
+    previous = con.sql(f"""
+        select score_per_100km from {FQ_TABLE}
+        where scored_at = (select max(scored_at) from {FQ_TABLE})
+    """).df()
+    if previous.empty:
+        return None
+
+    quantiles = [0.5, 0.9, 0.99]
+    old_q = previous["score_per_100km"].quantile(quantiles)
+    new_q = new["score_per_100km"].quantile(quantiles)
+    report = {
+        f"p{int(q * 100)}": {
+            "previous": round(float(old_q.loc[q]), 3),
+            "current": round(float(new_q.loc[q]), 3),
+            "pct_change": round(
+                100 * (new_q.loc[q] - old_q.loc[q]) / max(abs(old_q.loc[q]), 1e-9), 1
+            ),
+        }
+        for q in quantiles
+    }
+    report["n_previous"] = int(len(previous))
+    report["n_current"] = int(len(new))
+    worst = max(abs(report[f"p{int(q * 100)}"]["pct_change"]) for q in quantiles)
+    report["max_abs_pct_change"] = float(worst)
+    # Plain bool, not numpy.bool_, or json.dumps refuses it.
+    report["flagged"] = bool(worst > 25.0)
+    return report
+
+
+def write_scores(warehouse: Path, scores: pd.DataFrame) -> dict | None:
+    """Append this run to the score table, keeping prior runs for comparison."""
+    with duckdb.connect(str(warehouse)) as con:
+        con.sql(f"create schema if not exists {SCORE_SCHEMA}")
+        drift = drift_report(con, scores)
+        con.register("new_scores", scores)
+        exists = con.sql(f"""
+            select count(*) from information_schema.tables
+            where table_schema = '{SCORE_SCHEMA}' and table_name = '{SCORE_TABLE}'
+        """).fetchone()[0]
+        if exists:
+            con.sql(f"insert into {FQ_TABLE} select * from new_scores")
+        else:
+            con.sql(f"create table {FQ_TABLE} as select * from new_scores")
+        con.unregister("new_scores")
+    return drift
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Score the forecast year.")
+    parser.add_argument("--warehouse", type=Path, default=features.DEFAULT_WAREHOUSE)
+    parser.add_argument("--output-dir", type=Path, default=Path("ml/results"))
+    parser.add_argument(
+        "--no-challenger", action="store_true", help="skip the LightGBM comparison score"
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)-7s %(message)s")
+
+    panel, forecast = load_scoring_frames(args.warehouse)
+    if forecast.empty:
+        logger.error("no forecast-year rows; rebuild the warehouse with `make transform`")
+        return 1
+    target_year = int(forecast["panel_year"].iloc[0])
+    logger.info(
+        "fitting on %s complete pipe-years (%s-%s), scoring %s",
+        f"{len(panel):,}",
+        int(panel["panel_year"].min()),
+        int(panel["panel_year"].max()),
+        target_year,
+    )
+
+    ranker = StratifiedRateRanker().fit(panel)
+    logger.info("ranker %s: %s cells", ranker.version, len(ranker.table_))
+
+    challenger_scores, challenger_version = None, None
+    if not args.no_challenger:
+        model = train.fit_lgbm(panel, "full")
+        challenger_scores = train.predict(model, forecast, "full")
+        challenger_version = (
+            "lgbm-"
+            + hashlib.sha256(
+                json.dumps(model.get_params(), sort_keys=True, default=str).encode()
+            ).hexdigest()[:12]
+        )
+        logger.info("challenger %s: %s trees", challenger_version, model.n_estimators_)
+
+    scores = build_inspection_list(ranker, forecast, challenger_scores, challenger_version)
+    drift = write_scores(args.warehouse, scores)
+
+    total_km = scores["length_km"].sum()
+    print(f"\n===== INSPECTION LIST FOR {target_year} =====")
+    print(f"network: {len(scores):,} segments, {total_km:.0f} km\n")
+    rows = []
+    total_expected = scores["expected_breaks"].sum()
+    for budget in BUDGET_GRID:
+        cut = scores[scores["pct_of_network_km"] <= budget]
+        caught = cut["expected_breaks"].sum()
+        rows.append(
+            {
+                "budget": f"{budget:.0%}",
+                "km": round(cut["length_km"].sum(), 1),
+                "segments": len(cut),
+                "expected_breaks": round(caught, 1),
+                "share_of_expected": f"{caught / total_expected:.0%}",
+            }
+        )
+    print(pd.DataFrame(rows).to_string(index=False))
+
+    # Within a cell every segment carries the same rate, so a per-segment rank
+    # is arbitrary -- an empirical check across eight years put the two opposite
+    # tiebreaks 0.9 points apart, inside the noise. The cell is the unit that
+    # carries information, so that is what gets shown.
+    print("\n===== RISK CELLS, WORST FIRST =====")
+    cells = (
+        scores.groupby("risk_cell", observed=True)
+        .agg(
+            segments=("watmainid", "size"),
+            km=("length_km", "sum"),
+            rate_per_100km=("score_per_100km", "first"),
+            expected_breaks=("expected_breaks", "sum"),
+            evidence_breaks=("cell_breaks", "first"),
+        )
+        .sort_values("rate_per_100km", ascending=False)
+        .head(10)
+        .round(2)
+    )
+    print(cells.to_string())
+
+    print("\n===== TOP 10 SEGMENTS (length in metres) =====")
+    top = scores.head(10)[["rank", "watmainid", "risk_cell", "score_per_100km"]].copy()
+    top["length_m"] = (scores.head(10)["length_km"] * 1000).round(0)
+    print(top.round(2).to_string(index=False))
+
+    if drift:
+        print("\n===== SCORE DRIFT vs PREVIOUS RUN =====")
+        print(json.dumps(drift, indent=2))
+        if drift["flagged"]:
+            logger.warning("score distribution moved >25%%; check upstream before acting")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    scores.to_csv(args.output_dir / f"inspection_list_{target_year}.csv", index=False)
+    logger.info("wrote %s rows to %s", f"{len(scores):,}", FQ_TABLE)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ml_ranker.py
+++ b/tests/test_ml_ranker.py
@@ -1,0 +1,155 @@
+"""Tests for the shipped ranker and the scoring pipeline.
+
+The ranker is a lookup table, so most of what can go wrong is not arithmetic
+but discipline: fitting on the wrong rows, silently scoring a cell it has never
+seen, or producing a version that does not move when the table does.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ml.ranker import StratifiedRateRanker
+from ml.score import build_inspection_list
+
+
+def _train(rows: list[tuple]) -> pd.DataFrame:
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "prior_break_count_capped",
+            "material",
+            "install_decade",
+            "break_count",
+            "length_km",
+            "panel_year",
+            "is_complete_year",
+        ],
+    )
+
+
+BASE = _train(
+    [
+        (0, "CI", "1950s", 40, 100.0, 2020, True),
+        (0, "PVC", "2000s", 1, 100.0, 2020, True),
+        (3, "CI", "1950s", 60, 50.0, 2020, True),
+    ]
+)
+
+
+def test_fit_refuses_incomplete_years():
+    """An incomplete year has partly observed outcomes; fitting on it would put
+    the answer into the score."""
+    bad = BASE.copy()
+    bad.loc[0, "is_complete_year"] = False
+    with pytest.raises(ValueError, match="complete years only"):
+        StratifiedRateRanker().fit(bad)
+
+
+def test_rate_ordering_follows_the_data():
+    ranker = StratifiedRateRanker(smoothing_km=0.0).fit(BASE)
+    test = BASE[["prior_break_count_capped", "material", "install_decade"]]
+    scores = ranker.predict(test)
+    # 60/50 > 40/100 > 1/100
+    assert scores[2] > scores[0] > scores[1]
+
+
+def test_smoothing_shrinks_thin_cells_toward_the_global_rate():
+    """A cell holding a few hundred metres must not outrank one built on
+    kilometres just because its numerator happened to be non-zero."""
+    thin = pd.concat([BASE, _train([(1, "CPP", "1980s", 1, 0.1, 2020, True)])], ignore_index=True)
+    unsmoothed = StratifiedRateRanker(smoothing_km=0.0).fit(thin)
+    smoothed = StratifiedRateRanker(smoothing_km=20.0).fit(thin)
+    cell = pd.DataFrame(
+        {"prior_break_count_capped": [1], "material": ["CPP"], "install_decade": ["1980s"]}
+    )
+    assert unsmoothed.predict(cell)[0] == pytest.approx(10.0)  # 1 break / 0.1 km
+    assert smoothed.predict(cell)[0] < 1.0
+
+
+def test_unseen_cell_falls_back_to_the_global_rate():
+    ranker = StratifiedRateRanker().fit(BASE)
+    unseen = pd.DataFrame(
+        {"prior_break_count_capped": [0], "material": ["HDPE"], "install_decade": ["2020s"]}
+    )
+    assert ranker.predict(unseen)[0] == pytest.approx(ranker.global_rate_)
+    assert bool(ranker.explain(unseen)["cell_is_unseen"].iloc[0]) is True
+
+
+def test_version_is_stable_for_identical_data_and_moves_when_the_table_does():
+    a = StratifiedRateRanker().fit(BASE)
+    b = StratifiedRateRanker().fit(BASE.copy())
+    assert a.version == b.version
+
+    changed = BASE.copy()
+    changed.loc[0, "break_count"] = 999
+    assert StratifiedRateRanker().fit(changed).version != a.version
+
+
+def test_explain_reports_the_evidence_behind_a_score():
+    ranker = StratifiedRateRanker().fit(BASE)
+    out = ranker.explain(BASE)
+    assert out.loc[2, "risk_cell"] == "3 | CI | 1950s"
+    assert out.loc[2, "cell_breaks"] == 60
+    assert out.loc[2, "cell_exposure_km"] == pytest.approx(50.0)
+
+
+def test_inspection_list_is_ranked_and_cumulative():
+    ranker = StratifiedRateRanker(smoothing_km=0.0).fit(BASE)
+    forecast = BASE.copy()
+    forecast["watmainid"] = [1, 2, 3]
+    forecast["panel_year"] = 2027
+
+    out = build_inspection_list(ranker, forecast, None, None)
+
+    assert list(out["rank"]) == [1, 2, 3]
+    assert out["score_per_100km"].is_monotonic_decreasing
+    assert out["cumulative_km"].is_monotonic_increasing
+    assert out["cumulative_km"].iloc[-1] == pytest.approx(forecast["length_km"].sum())
+    assert out["pct_of_network_km"].iloc[-1] == pytest.approx(1.0)
+    # The worst cell (60 breaks / 50 km) must lead.
+    assert out["watmainid"].iloc[0] == 3
+
+
+def test_expected_breaks_is_rate_times_length_not_the_ranking_key():
+    """Ranking on expected breaks would push long pipe up the list purely for
+    being long, which is wrong under a budget measured in kilometres.
+
+    The forecast frame is built separately from the training frame so the
+    lengths being scored are not the lengths the rates were fitted on -- which
+    is also how the real pipeline works.
+    """
+    ranker = StratifiedRateRanker(smoothing_km=0.0).fit(BASE)
+    # Fitted rates: (0, CI, 1950s) = 0.4/km, (3, CI, 1950s) = 1.2/km.
+    forecast = pd.DataFrame(
+        {
+            "watmainid": [1, 2],
+            "panel_year": [2027, 2027],
+            "prior_break_count_capped": [0, 3],
+            "material": ["CI", "CI"],
+            "install_decade": ["1950s", "1950s"],
+            # 0.4 x 100 km = 40 expected, against 1.2 x 10 km = 12.
+            "length_km": [100.0, 10.0],
+        }
+    )
+    out = build_inspection_list(ranker, forecast, None, None).set_index("watmainid")
+
+    assert out.loc[1, "expected_breaks"] > out.loc[2, "expected_breaks"]
+    # ...and yet the short, high-rate segment ranks first, because the budget
+    # is spent in kilometres.
+    assert out.loc[2, "rank"] < out.loc[1, "rank"]
+
+
+def test_challenger_scores_are_carried_but_do_not_reorder_the_list():
+    ranker = StratifiedRateRanker(smoothing_km=0.0).fit(BASE)
+    forecast = BASE.copy()
+    forecast["watmainid"] = [1, 2, 3]
+    forecast["panel_year"] = 2027
+    challenger = np.array([9.0, 9.0, 0.0])  # exactly opposite to the ranker
+
+    out = build_inspection_list(ranker, forecast, challenger, "lgbm-test")
+    assert out["watmainid"].iloc[0] == 3, "the challenger must not drive the ranking"
+    assert out["challenger_version"].iloc[0] == "lgbm-test"
+    assert set(out["challenger_rank"]) == {1, 2, 3}

--- a/transform/models/intermediate/int_pipe_year_spine.sql
+++ b/transform/models/intermediate/int_pipe_year_spine.sql
@@ -2,11 +2,15 @@
 -- risk. This is the grain change the whole project turns on -- it is what
 -- supplies the ~99.4% of rows where nothing broke.
 --
--- Two boundary rules:
+-- Three boundary rules:
 --   * History starts at `panel_start_year` (1997). Only 10 break records
 --     predate it, so earlier years would encode "no record" as "no break".
 --   * A pipe enters the panel the year AFTER installation, so no row carries a
 --     partial year of exposure.
+--   * The panel runs one year PAST the current year. That forecast year has no
+--     outcome and never will until it arrives -- it exists so the scoring
+--     pipeline has rows to score. An inspection list is for the year ahead;
+--     ranking the current year is half-pointless once it is half over.
 
 {% set current_year = "cast(extract(year from current_date) as integer)" %}
 
@@ -25,7 +29,7 @@ with pipes as (
 years as (
 
     select unnest(
-        generate_series({{ var('panel_start_year') }}, {{ current_year }})
+        generate_series({{ var('panel_start_year') }}, {{ current_year }} + 1)
     ) as panel_year
 
 )
@@ -38,6 +42,10 @@ select
     pipes.length_km,
 
     years.panel_year - pipes.install_year           as age_years,
+
+    -- The forecast year: features are as-of its 1 January, outcome unknown.
+    -- Excluded from training and from every rate table by is_complete_year.
+    years.panel_year > {{ current_year }}           as is_forecast_year,
 
     -- The current year is still accruing breaks. Training must exclude it or
     -- it drags the observed positive rate down; the flag makes that explicit

--- a/transform/models/marts/_marts__models.yml
+++ b/transform/models/marts/_marts__models.yml
@@ -52,6 +52,12 @@ models:
           - dbt_utils.accepted_range: {min_value: 1997, max_value: 2100}
       - name: broke_in_year
         data_tests: [not_null]
+      - name: is_forecast_year
+        description: >
+          The one year past the current year. Features are as-of its 1 January,
+          the outcome is unknown, and is_complete_year excludes it from training
+          and from every rate table. It exists so the scoring pipeline has rows.
+        data_tests: [not_null]
       - name: break_count
         data_tests:
           - not_null

--- a/transform/models/marts/fct_pipe_year.sql
+++ b/transform/models/marts/fct_pipe_year.sql
@@ -133,7 +133,8 @@ select
     winter.has_adequate_coverage                    as winter_has_adequate_coverage,
 
     -- ---- flags ----
-    spine.is_complete_year
+    spine.is_complete_year,
+    spine.is_forecast_year
 
 from spine
 left join history

--- a/transform/tests/assert_no_future_panel_years.sql
+++ b/transform/tests/assert_no_future_panel_years.sql
@@ -1,6 +1,7 @@
--- The panel must not extend past the current year.
+-- The panel may run one year past the current year -- that is the forecast row
+-- the scoring pipeline ranks -- but no further.
 
 select panel_year, count(*) as n
 from {{ ref('fct_pipe_year') }}
-where panel_year > cast(extract(year from current_date) as integer)
+where panel_year > cast(extract(year from current_date) as integer) + 1
 group by 1


### PR DESCRIPTION
## What this adds

`ml/ranker.py` (the shipped ranker as a fitted, explainable object), `ml/score.py` (scoring, writeback, drift), and a forecast year in the panel spine.

`python -m ml.score` — or `make score` — fits on complete years, scores the year ahead, and writes `main_scores.fct_pipe_risk_score`.

## It ships the lookup table, not the model

Phase 4 found the gradient-boosted model loses to a three-column lookup table on **both** strata — 20.6% vs 27.7% on pipes with no break history, 6.4% vs 10.5% on pipes with it. So `StratifiedRateRanker` is what the pipeline scores with. The LightGBM score is written alongside as `challenger_score`, so the comparison keeps running against new data instead of being settled once in a document.

`ml.baselines.stratified_rate_score` now **delegates** to `StratifiedRateRanker` rather than reimplementing it. That matters: wiring the evaluation to a separate implementation is how a model comes to score one way in a notebook and another way in production.

## A forecast year in the spine

The panel stopped at the current year, which is the wrong horizon — an inspection list for a year already three-quarters elapsed is three-quarters useless. The spine now runs one year past, flagged `is_forecast_year`: features as-of its 1 January, outcome unknown, excluded from training and from every rate table by `is_complete_year`. `assert_no_future_panel_years` was updated to allow exactly one forecast year and no more.

## Output

For 2027, across 15,552 segments and 938 km:

| Budget | Length | Segments | Expected breaks | Share of expected |
|---|---|---|---|---|
| 1% | 9.2 km | 62 | 5.2 | 7% |
| 2% | 18.7 km | 97 | 10.4 | 14% |
| **5%** | **46.9 km** | **257** | **22.7** | **30%** |
| 10% | 93.7 km | 620 | 38.3 | 51% |

The 5% row reading 30% is an independent check on the walk-forward `capture@5%` of 30.1% from phase 4 — different code paths, same answer.

The table is written by `ml/score.py` rather than dbt and lives in its own schema to make that ownership boundary visible. Each run appends, stamped with `scored_at` and a `method_version` hashed from the fitted table's own contents.

## Explanation without SHAP

The plan called for persisted SHAP values. A lookup table doesn't need an attribution method — the explanation *is* the computation. Every score carries its cell, that cell's rate, and the evidence beneath it:

| Cell | Segments | km | Rate /100km/yr | Evidence |
|---|---|---|---|---|
| 3 prior \| CI \| 1950s | 90 | 17.8 | 56.3 | 123 breaks |
| 3 prior \| DI \| 1970s | 17 | 3.4 | 48.3 | 21 breaks |
| 3 prior \| CI \| 1960s | 83 | 16.9 | 43.5 | 102 breaks |

`cell_is_unseen` flags rows scored by the smoothing prior rather than by observed history.

## Reviewer notes

**Per-segment rank carries no information, and this constrains phase 6.** 111 cells cover ~15,500 segments, so most of the list is ordered by the tiebreak rather than the score. I measured this rather than assuming it: reversing the tiebreak (longest-first instead of shortest-first) moves `capture@5%` from 29.3% to 28.4% across eight years — inside the noise. The console output therefore leads with risk cells, and **the app must surface the cell, never imply that segment #204 is riskier than #205.**

**Two bugs found while building it, both fixed:**
- The first list had sub-metre GIS connector artifacts in its top ten. They were excluded when fitting but not when scoring, and they share a cell rate with real pipe while winning the shortest-first tiebreak. An inspection list of 80 cm stubs is unactionable.
- The drift report crashed on `json.dumps` — `numpy.bool_` isn't serialisable.

**Ranking is per km, not per segment.** `expected_breaks` (rate × length) is written for the app to total, but ranking on it would push long pipe up the list purely for being long, which is wrong under a budget measured in kilometres. There's a test pinning that distinction.

**Drift.** Each run compares p50/p90/p99 against the previous and flags a move over 25%. A refit on one more year should barely move; a large jump means something upstream changed — a join fanned out, a material got recoded, an extract came back short.

**Verified locally:** ruff clean, 36 python tests pass (9 new), 77 dbt tests pass.

## Not included

`notebooks/01_initial_preprocessing.ipynb` and `notebooks/02_baseline_eda.ipynb` still carry unrelated uncommitted local changes (~658k lines of re-executed cell output in the latter). Excluded from every PR in this series and left in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
